### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.3
+FROM alpine:3.18
 MAINTAINER tgraf@noironetworks.com
 
 ADD super_netperf /sbin/
 
 RUN \
 	apk add --update curl build-base bash && \
-	curl -LO ftp://ftp.netperf.org/netperf/netperf-2.7.0.tar.gz && \
+	curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz && \
 	tar -xzf netperf-2.7.0.tar.gz  && \
-	cd netperf-2.7.0 && ./configure --prefix=/usr && make && make install && \
-	rm -rf netperf-2.7.0 netperf-2.7.0.tar.gz && \
+	cd netperf-netperf-2.7.0 && ./configure --prefix=/usr && make CFLAGS=-fcommon && make install && \
+	rm -rf /netperf-netperf-2.7.0 /netperf-2.7.0.tar.gz && \
 	rm -f /usr/share/info/netperf.info && \
 	strip -s /usr/bin/netperf /usr/bin/netserver && \
 	apk del build-base && rm -rf /var/cache/apk/*


### PR DESCRIPTION
- Pick up the latest Alpine. Alpine 3.3 has an expired Let's Encrypt root certificate [^1], and "curl https://cilium.io/" fails with an error: "curl: (60) SSL certificate problem: certificate has expired"
- Update the URL to download netperf-2.7.0 from. The FTP site no longer hosts the netperf-2.7.0.tar.gz file.
- Pass CFLAGS=-fcommon to make to fix a compilation error [^2].

[^1]: https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
[^2]: https://github.com/HewlettPackard/netperf/issues/59